### PR TITLE
Fix: images stretching on safari browsers

### DIFF
--- a/components/common/Article.tsx
+++ b/components/common/Article.tsx
@@ -13,6 +13,7 @@ const useStyles = makeStyles(({ spacing }) => ({
     link: {
         display: "flex",
         width: "100%",
+        alignItems: "flex-start",
     },
     header: {
         width: "100%",

--- a/components/common/BrandCollab.tsx
+++ b/components/common/BrandCollab.tsx
@@ -15,6 +15,7 @@ const useStyles = makeStyles<
     }),
     half: ({ variant }) => ({
         display: "flex",
+        alignItems: "flex-start",
 
         ...(variant === "vertical"
             ? {}


### PR DESCRIPTION
Safari has weird default stylings for images in flex-box, this sets a more sensible alignment

- ref: https://stackoverflow.com/questions/57516373/image-stretching-in-flexbox-in-safari